### PR TITLE
Fix darwin races chiptool

### DIFF
--- a/scripts/tests/test_suites.sh
+++ b/scripts/tests/test_suites.sh
@@ -19,7 +19,7 @@
 set -e
 
 declare -a test_array="($(find src/app/tests/suites -type f -name "*.yaml" -exec basename {} .yaml \;))"
-declare -i iterations=20
+declare -i iterations=1000
 declare -i background_pid=0
 
 cleanup() {
@@ -45,6 +45,8 @@ done
 echo ""
 echo ""
 
+ulimit -c unlimited || true
+
 declare -a iter_array="($(seq "$iterations"))"
 for j in "${iter_array[@]}"; do
     echo " ===== Iteration $j starting"
@@ -54,6 +56,7 @@ for j in "${iter_array[@]}"; do
         rm -rf /tmp/chip_tool_config.ini
         out/debug/chip-all-clusters-app &
         background_pid=$!
+        sleep 0.1
         echo "          * Pairing to device"
         out/debug/standalone/chip-tool pairing onnetwork 1 20202021 3840 ::1 11097
         echo "          * Starting test run: $i"

--- a/src/inet/RawEndPoint.cpp
+++ b/src/inet/RawEndPoint.cpp
@@ -38,6 +38,8 @@
 #include <support/logging/CHIPLogging.h>
 #include <system/SystemFaultInjection.h>
 
+#include <platform/CHIPDeviceLayer.h>
+
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #include <lwip/ip.h>
 #include <lwip/raw.h>
@@ -226,9 +228,12 @@ INET_ERROR RawEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, Int
 
         dispatch_source_set_event_handler(mReadableSource, ^{
             SocketEvents res;
+
+            chip::DeviceLayer::PlatformMgr().LockChipStack();
             res.SetRead();
             this->mPendingIO = res;
             this->HandlePendingIO();
+            chip::DeviceLayer::PlatformMgr().UnlockChipStack();
         });
 
         dispatch_resume(mReadableSource);

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -37,6 +37,7 @@
 #include "InetFaultInjection.h"
 #include <inet/InetLayer.h>
 
+#include <platform/PlatformManager.h>
 #include <support/CodeUtils.h>
 #include <support/SafeInt.h>
 #include <support/logging/CHIPLogging.h>
@@ -256,16 +257,28 @@ INET_ERROR TCPEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, uin
 
         dispatch_source_set_event_handler(mReadableSource, ^{
             SocketEvents events;
+
+            chip::DeviceLayer::PlatformMgr().LockChipStack();
+            
             events.SetRead();
             this->mPendingIO = events;
             this->HandlePendingIO();
+
+            chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+            
         });
 
         dispatch_source_set_event_handler(mWriteableSource, ^{
             SocketEvents events;
+
+            chip::DeviceLayer::PlatformMgr().LockChipStack();
+            
             events.SetWrite();
             this->mPendingIO = events;
             this->HandlePendingIO();
+
+            chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+            
         });
 
         dispatch_resume(mReadableSource);

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -33,6 +33,7 @@
 #include "InetFaultInjection.h"
 #include <inet/InetLayer.h>
 
+#include <platform/PlatformManager.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 #include <system/SystemFaultInjection.h>
@@ -257,9 +258,14 @@ INET_ERROR UDPEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, uin
 
         dispatch_source_set_event_handler(mReadableSource, ^{
             SocketEvents res;
+
+            chip::DeviceLayer::PlatformMgr().LockChipStack();
+            
             res.SetRead();
             this->mPendingIO = res;
             this->HandlePendingIO();
+
+            chip::DeviceLayer::PlatformMgr().UnlockChipStack();
         });
         dispatch_resume(mReadableSource);
     }

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -173,6 +173,7 @@ public:
 
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
     void SetDispatchQueue(dispatch_queue_t dispatchQueue) { mDispatchQueue = dispatchQueue; };
+    void SetLock(pthread_mutex_t &lock);
     dispatch_queue_t GetDispatchQueue() { return mDispatchQueue; };
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 

--- a/src/system/SystemTimer.cpp
+++ b/src/system/SystemTimer.cpp
@@ -187,7 +187,9 @@ Error Timer::Start(uint32_t aDelayMilliseconds, OnCompleteFunct aOnComplete, voi
             dispatch_source_cancel(timerSource);
             dispatch_release(timerSource);
 
+            //chip::DeviceLayer::PlatformMgr().LockChipStack();
             this->HandleComplete();
+            //chip::DeviceLayer::PlatformMgr().UnlockChipStack();
         });
         dispatch_resume(timerSource);
     }
@@ -224,7 +226,9 @@ Error Timer::ScheduleWork(OnCompleteFunct aOnComplete, void * aAppState)
     if (dispatchQueue)
     {
         dispatch_async(dispatchQueue, ^{
+            //chip::DeviceLayer::PlatformMgr().LockChipStack();
             this->HandleComplete();
+            //chip::DeviceLayer::PlatformMgr().UnlockChipStack();
         });
     }
     else


### PR DESCRIPTION
 #### Problem
* tsan when run against chip-tool on darwin detected numerous data races, some resulting in segmentation faults (see [this](https://github.com/project-chip/connectedhomeip/issues/7574))

#### Summary of Changes

* Fixes the Darwin's PlatformManagerImpl to be compliant with the API expectations defined in PlatformManager.h, namely:
    * Correctly pause/resume the CHIP dispatch queue at the right functions.
    * Ensure synchronous shutdown of the dispatch queue
    * Implement the stack lock APIs
    * Lock/Unlock when dispatching blocks
    
#### Testing

* Repro'ed the original segmentation fault as well as many tsan failures with chip-tool on Darwin `scripts/tests/test_suites.sh`. 
* After fixes, 1000 runs of the test suite did not result in any seg faults, nor any tsan failures.